### PR TITLE
feat: added Topic::child method that returns a child topic

### DIFF
--- a/src/topic.rs
+++ b/src/topic.rs
@@ -109,6 +109,11 @@ impl Topic {
         &mut self.name
     }
 
+    /// Creates a child topic
+    pub fn child(&self, name: &str) -> Self{
+        Self::new(self.name.clone() + name, self.handle.clone())
+    }
+
     /// Publishes to this topic with the data type `T`.
     ///
     /// For a generic-free version, see [`generic_publish`][`Self::generic_publish`].


### PR DESCRIPTION
Working with this, I needed to access multiple different topics from the same prefix. While I could have simply used a string for my prefix (which is what I am doing now), I figured it would be more intuitive to add a function that returns a "child" topic. Feel free to change anything about this; I am definitely not the best Rust programmer.